### PR TITLE
fix: Allow to set region and project ID:

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ module "my_domain" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_domain"></a> [domain](#input_domain) | n/a | `string` | n/a | yes |
 | <a name="input_mx_servers"></a> [mx_servers](#input_mx_servers) | n/a | ```list(object({ address = string priority = number }))``` | ```[ { "address": ".", "priority": 0 } ]``` | no |
-| <a name="input_project_id"></a> [project_id](#input_project_id) | ID of the project the domain is associated with. Ressource will be created in the region set by the provider if null. | `string` | `"null"` | no |
-| <a name="input_region"></a> [region](#input_region) | Region in which the domain should be created. Ressource will be created in the region set by the provider if null. | `string` | `"null"` | no |
-| <a name="input_setup_tem"></a> [setup_tem](#input_setup_tem) | n/a | `bool` | `false` | no |
+| <a name="input_project_id"></a> [project_id](#input_project_id) | ID of the project the domain is associated with. Ressource will be created in the project set at the provider level if null. | `string` | `null` | no |
+| <a name="input_setup_tem"></a> [setup_tem](#input_setup_tem) | Whether to create a Transaction Email service. **Beware that the service is only available in region `fr-par` at the moment.** | `bool` | `false` | no |
 | <a name="input_subdomain"></a> [subdomain](#input_subdomain) | n/a | `string` | `""` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,6 @@ resource "scaleway_tem_domain" "this" {
 
   name       = local.dns_zone
   project_id = var.project_id
-  region     = var.region
 }
 
 resource "scaleway_domain_record" "dkim" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,13 +14,7 @@ variable "mx_servers" {
 }
 
 variable "project_id" {
-  description = "ID of the project the domain is associated with. Ressource will be created in the region set by the provider if null."
-  type        = string
-  default     = null
-}
-
-variable "region" {
-  description = "Region in which the domain should be created. Ressource will be created in the region set by the provider if null."
+  description = "ID of the project the domain is associated with. Ressource will be created in the project set at the provider level if null."
   type        = string
   default     = null
 }
@@ -31,6 +25,7 @@ variable "subdomain" {
 }
 
 variable "setup_tem" {
-  type    = bool
-  default = false
+  type        = bool
+  description = "Whether to create a Transaction Email service. **Beware that the service is only available in region `fr-par` at the moment.**"
+  default     = false
 }


### PR DESCRIPTION
* Remove variable `region` as the only service that support it (tem) is only available in `fr-par`.
* Add warning in documentation about transaction email only available in `fr-par`.

Should resolve #3 