### PR TITLE
chore(deps): bump terraform-provider-scaleway from 2.6.0 to 2.14.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ module "my_domain" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13 |
-| <a name="requirement_scaleway"></a> [scaleway](#requirement_scaleway) | >= 2.6.0 |
+| <a name="requirement_scaleway"></a> [scaleway](#requirement_scaleway) | >= 2.14.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ resource "scaleway_domain_zone" "this" {
 resource "scaleway_tem_domain" "this" {
   count = var.setup_tem ? 1 : 0
 
+  accept_tos = true
   name       = local.dns_zone
   project_id = var.project_id
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     scaleway = {
       source  = "scaleway/scaleway"
-      version = ">= 2.6.0"
+      version = ">= 2.14.0"
     }
   }
 }


### PR DESCRIPTION
- Add the accept_tos mandatory attribute to resource scaleway_tem_domain.this[0].